### PR TITLE
feat: switch from OpenVSCode to VSCodium reh-web 1.121.03429

### DIFF
--- a/cmd/devssh/agent.go
+++ b/cmd/devssh/agent.go
@@ -13,10 +13,10 @@ func newAgentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Manage VSCode installation and running",
-		Long: `Manage VSCode (openvscode-server) installation and running on the current machine.
+		Long: `Manage VSCode (VSCodium reh-web) installation and running on the current machine.
 
 Commands:
-  install     Download and install openvscode-server
+  install     Download and install VSCodium reh-web
   start       Start VSCode
   stop        Stop VSCode
   uninstall   Uninstall VSCode and clean up
@@ -25,8 +25,8 @@ Commands:
 
 Examples:
   devssh agent install
-  devssh agent install --version v1.105.1
-  devssh agent install --local-tar /path/to/openvscode.tar.gz
+  devssh agent install --version 1.121.03429
+  devssh agent install --local-tar /path/to/vscodium-reh-web.tar.gz
   devssh agent start --port 10081
   devssh agent stop
   devssh agent uninstall
@@ -55,8 +55,8 @@ func newAgentInstallCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Download and install openvscode-server",
-		Long: `Download and install openvscode-server to the working directory.
+		Short: "Download and install VSCodium reh-web",
+		Long: `Download and install VSCodium reh-web to the working directory.
 If already installed, this command will be skipped.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner, err := agent.NewRunner()
@@ -86,7 +86,7 @@ If already installed, this command will be skipped.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&version, "version", "v1.105.1", "VSCode version to install")
+	cmd.Flags().StringVar(&version, "version", "1.121.03429", "VSCode version to install")
 	cmd.Flags().StringVar(&localTar, "local-tar", "", "Path to local tar.gz file (use this instead of downloading)")
 
 	return cmd
@@ -98,7 +98,7 @@ func newAgentStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start VSCode",
-		Long: `Start openvscode-server on the specified port.
+		Long: `Start VSCodium reh-web on the specified port.
 If VSCode is already running, this command will be skipped.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner, err := agent.NewRunner()
@@ -195,7 +195,7 @@ func newAgentIsRunningCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "is-running",
 		Short: "Check if VSCode is running",
-		Long:  `Check if VSCode (openvscode-server) is currently running.`,
+		Long:  `Check if VSCode (VSCodium reh-web) is currently running.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner, err := agent.NewRunner()
 			if err != nil {
@@ -218,7 +218,7 @@ func newAgentGetPortCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-port",
 		Short: "Get the port VSCode is running on",
-		Long:  `Get the port number that VSCode (openvscode-server) is running on.`,
+		Long:  `Get the port number that VSCode (VSCodium reh-web) is running on.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner, err := agent.NewRunner()
 			if err != nil {

--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	version = "0.1.6"
+	version = "0.1.7"
 	logger  log.Logger
 )
 

--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -169,7 +169,7 @@ func newUpCmd() *cobra.Command {
 	cmd.Flags().StringVar(&password, "password", "", "SSH password")
 	cmd.Flags().StringVar(&ideType, "ide", "vscode", "Web IDE type (vscode, code-server)")
 	cmd.Flags().IntVar(&idePort, "ide-port", 10081, "Port for IDE")
-	cmd.Flags().StringVar(&version, "version", "v1.105.1", "IDE version")
+	cmd.Flags().StringVar(&version, "version", "1.121.03429", "IDE version")
 	cmd.Flags().StringSliceVar(&forwards, "forward", []string{}, "Ports to forward (e.g., 3000, 8080:80)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Auto-detect and forward web service ports")
 	cmd.Flags().IntVar(&timeout, "timeout", 30, "SSH connection timeout in seconds")

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -165,7 +165,7 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	}
 
 	logger.Infof("Checking VSCode installation on remote...")
-	vscodeCheckCmd := "test -f ~/.devssh/openvscode/bin/openvscode-server && echo 'installed' || echo 'not_installed'"
+	vscodeCheckCmd := "test -f ~/.devssh/vscodium/bin/codium-server && echo 'installed' || echo 'not_installed'"
 	checkOutput, checkErr := client.RunCommand(vscodeCheckCmd)
 	if checkErr != nil {
 		return fmt.Errorf("failed to check remote VSCode: %w", checkErr)
@@ -178,13 +178,13 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 			return fmt.Errorf("failed to download VSCode: %w", err)
 		}
 
-		logger.Infof("Uploading VSCode to remote...")
-		if err := uploadToRemote(client, vscodePath, "~/.devssh/openvscode.tar.gz"); err != nil {
-			return fmt.Errorf("failed to upload VSCode: %w", err)
+		logger.Infof("Uploading VSCodium to remote...")
+		if err := uploadToRemote(client, vscodePath, "~/.devssh/vscodium-reh-web.tar.gz"); err != nil {
+			return fmt.Errorf("failed to upload VSCodium: %w", err)
 		}
 
-		logger.Infof("Installing VSCode on remote...")
-		if _, err := runRemoteAgentCommand(client, "install --local-tar ~/.devssh/openvscode.tar.gz"); err != nil {
+		logger.Infof("Installing VSCodium on remote...")
+		if _, err := runRemoteAgentCommand(client, "install --local-tar ~/.devssh/vscodium-reh-web.tar.gz"); err != nil {
 			return fmt.Errorf("failed to install VSCode: %w", err)
 		}
 	} else {

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Sylens Wong <qiumin14@163.com>"]
 channels = ["conda-forge"]
 name = "DevSSH"
 platforms = ["linux-aarch64", "linux-64"]
-version = "0.1.6"
+version = "0.1.7"
 preview = ["pixi-build"]
 
 [tasks.clean]
@@ -34,7 +34,7 @@ go = ">=1.25.4,<2"
 
 [package]
 name = "DevSSH"
-version = "0.1.6"
+version = "0.1.7"
 
 [package.build.backend]
 name = "pixi-build-rattler-build"

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -20,15 +20,15 @@ import (
 )
 
 const (
-	DefaultVersion = "v1.105.1"
+	DefaultVersion = "1.121.03429"
 )
 
 type Runner struct {
-	workDir       string
-	logFile       string
-	openvscodeDir string
-	serverPath    string
-	serverPID     int
+	workDir    string
+	logFile    string
+	vscodiumDir string
+	serverPath string
+	serverPID  int
 }
 
 func NewRunner() (*Runner, error) {
@@ -43,13 +43,13 @@ func NewRunner() (*Runner, error) {
 	}
 
 	logFile := filepath.Join(workDir, "agent.log")
-	openvscodeDir := filepath.Join(workDir, "openvscode")
+	vscodiumDir := filepath.Join(workDir, "vscodium")
 
 	return &Runner{
-		workDir:       workDir,
-		logFile:       logFile,
-		openvscodeDir: openvscodeDir,
-		serverPath:    filepath.Join(openvscodeDir, "bin", "openvscode-server"),
+		workDir:     workDir,
+		logFile:     logFile,
+		vscodiumDir: vscodiumDir,
+		serverPath:  filepath.Join(vscodiumDir, "bin", "codium-server"),
 	}, nil
 }
 
@@ -62,11 +62,11 @@ func (r *Runner) Install(version string) error {
 		return nil
 	}
 
-	logging.Infof("Downloading openvscode-server...")
+	logging.Infof("Downloading VSCodium reh-web...")
 
 	url := download.GetVSCodeDownloadURL(version, runtime.GOOS, runtime.GOARCH)
 	logging.Infof("%s", url)
-	downloadPath := filepath.Join(r.workDir, fmt.Sprintf("openvscode-server-%s.tar.gz", version))
+	downloadPath := filepath.Join(r.workDir, fmt.Sprintf("vscodium-reh-web-%s.tar.gz", version))
 
 	if err := r.download(url, downloadPath); err != nil {
 		return fmt.Errorf("failed to download: %w", err)
@@ -74,8 +74,8 @@ func (r *Runner) Install(version string) error {
 
 	logging.Infof("Extracting...")
 
-	if err := os.MkdirAll(r.openvscodeDir, 0755); err != nil {
-		return fmt.Errorf("failed to create openvscode directory: %w", err)
+	if err := os.MkdirAll(r.vscodiumDir, 0755); err != nil {
+		return fmt.Errorf("failed to create vscodium directory: %w", err)
 	}
 
 	if err := r.extract(downloadPath); err != nil {
@@ -219,7 +219,7 @@ func (r *Runner) extract(archivePath string) error {
 
 		firstComponent := strings.Split(name, "/")[0]
 
-		if strings.HasPrefix(name, "openvscode-server-") && strings.Contains(name, "/") {
+		if strings.HasPrefix(name, "vscodium-reh-web-") && strings.Contains(name, "/") {
 			parts := strings.SplitN(name, "/", 2)
 			if len(parts) > 1 {
 				name = parts[1]
@@ -230,7 +230,7 @@ func (r *Runner) extract(archivePath string) error {
 			continue
 		}
 
-		targetPath := filepath.Join(r.openvscodeDir, name)
+		targetPath := filepath.Join(r.vscodiumDir, name)
 
 		switch header.Typeflag {
 		case tar.TypeDir:
@@ -256,7 +256,7 @@ func (r *Runner) extract(archivePath string) error {
 		case tar.TypeSymlink:
 			linkTarget := header.Linkname
 
-			if strings.HasPrefix(linkTarget, "openvscode-server-") {
+			if strings.HasPrefix(linkTarget, "vscodium-reh-web-") {
 				parts := strings.SplitN(linkTarget, "/", 2)
 				if len(parts) > 1 {
 					linkTarget = parts[1]
@@ -264,7 +264,7 @@ func (r *Runner) extract(archivePath string) error {
 			}
 
 			if !filepath.IsAbs(linkTarget) {
-				linkTarget = filepath.Join(r.openvscodeDir, linkTarget)
+				linkTarget = filepath.Join(r.vscodiumDir, linkTarget)
 			}
 
 			dir := filepath.Dir(targetPath)
@@ -362,10 +362,10 @@ func (r *Runner) InstallFromTar(tarPath string) error {
 		return nil
 	}
 
-	logging.Infof("Installing VSCode from local tar.gz...")
+	logging.Infof("Installing VSCodium from local tar.gz...")
 
-	if err := os.MkdirAll(r.openvscodeDir, 0755); err != nil {
-		return fmt.Errorf("failed to create openvscode directory: %w", err)
+	if err := os.MkdirAll(r.vscodiumDir, 0755); err != nil {
+		return fmt.Errorf("failed to create vscodium directory: %w", err)
 	}
 
 	if err := r.extract(tarPath); err != nil {
@@ -384,8 +384,8 @@ func (r *Runner) Uninstall() error {
 	}
 
 	if r.IsInstalled() {
-		if err := os.RemoveAll(r.openvscodeDir); err != nil {
-			return fmt.Errorf("failed to remove openvscode directory: %w", err)
+		if err := os.RemoveAll(r.vscodiumDir); err != nil {
+			return fmt.Errorf("failed to remove vscodium directory: %w", err)
 		}
 	}
 
@@ -399,8 +399,8 @@ func (r *Runner) GetWorkDir() string {
 	return r.workDir
 }
 
-func (r *Runner) GetOpenVSCodeDir() string {
-	return r.openvscodeDir
+func (r *Runner) GetVSCodiumDir() string {
+	return r.vscodiumDir
 }
 
 func (r *Runner) GetServerPath() string {

--- a/pkg/download/local_downloader.go
+++ b/pkg/download/local_downloader.go
@@ -52,7 +52,7 @@ func (d *LocalDownloader) Download(url string) (string, error) {
 
 func (d *LocalDownloader) DownloadVSCode(version, os, arch string) (string, error) {
 	if version == "" {
-		version = "v1.105.1"
+		version = "1.121.03429"
 	}
 
 	url := d.GetVSCodeDownloadURL(version, os, arch)
@@ -65,24 +65,24 @@ func (d *LocalDownloader) GetVSCodeDownloadURL(version, os, arch string) string 
 }
 
 func GetVSCodeDownloadURL(version, os, arch string) string {
-	baseURL := fmt.Sprintf("https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-%s/openvscode-server-%s", version, version)
+	baseURL := fmt.Sprintf("https://github.com/VSCodium/vscodium/releases/download/%s/vscodium-reh-web", version)
 
 	switch os {
 	case "linux":
 		if arch == "amd64" {
-			return baseURL + "-linux-x64.tar.gz"
+			return baseURL + "-linux-x64-" + version + ".tar.gz"
 		} else if arch == "arm64" {
-			return baseURL + "-linux-arm64.tar.gz"
+			return baseURL + "-linux-arm64-" + version + ".tar.gz"
 		}
 	case "darwin":
 		if arch == "amd64" {
-			return baseURL + "-darwin-x64.tar.gz"
+			return baseURL + "-darwin-x64-" + version + ".tar.gz"
 		} else if arch == "arm64" {
-			return baseURL + "-darwin-arm64.tar.gz"
+			return baseURL + "-darwin-arm64-" + version + ".tar.gz"
 		}
 	}
 
-	return baseURL + fmt.Sprintf("-%s-%s.tar.gz", os, arch)
+	return baseURL + fmt.Sprintf("-%s-%s-%s.tar.gz", os, arch, version)
 }
 
 func (d *LocalDownloader) getCachePath(url string) (string, error) {

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,6 +1,6 @@
 package:
   name: devssh
-  version: 0.1.6
+  version: 0.1.7
 
 source:
   path: .


### PR DESCRIPTION
Replace OpenVSCode with VSCodium reh-web (1.121.03429) as the web IDE distribution.

Changes:
- Download URL from `gitpod-io/openvscode-server` → `VSCodium/vscodium` reh-web
- Install directory: `~/.devssh/openvscode/` → `~/.devssh/vscodium/`
- Server binary: `bin/openvscode-server` → `bin/codium-server`
- Default version: `v1.105.1` → `1.121.03429`
- Extraction logic adapts `vscodium-reh-web-*` tar directory prefix
- Remote check/upload paths updated accordingly

Closes SIL-54