### PR TITLE
feat: SSH connection keepalive monitoring and auto-reconnect (SIL-59)

### DIFF
--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	version = "0.1.7"
+	version = "0.1.8"
 	logger  log.Logger
 )
 

--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -77,16 +77,18 @@ func main() {
 
 func newUpCmd() *cobra.Command {
 	var (
-		user     string
-		port     string
-		keyPath  string
-		password string
-		ideType  string
-		idePort  int
-		version  string
-		forwards []string
-		auto     bool
-		timeout  int
+		user             string
+		port             string
+		keyPath          string
+		password         string
+		ideType          string
+		idePort          int
+		version          string
+		forwards         []string
+		auto             bool
+		timeout          int
+		keepalive        bool
+		keepaliveInt     int
 	)
 
 	cmd := &cobra.Command{
@@ -106,13 +108,17 @@ func newUpCmd() *cobra.Command {
 				overrideConfig := &ssh.Config{
 					Host: host,
 
-					Username: user,
-					KeyPath:  keyPath,
-					Password: password,
-					Timeout:  time.Duration(timeout) * time.Second,
+					Username:          user,
+					KeyPath:           keyPath,
+					Password:          password,
+					Timeout:           time.Duration(timeout) * time.Second,
+					KeepaliveInterval: time.Duration(keepaliveInt) * time.Second,
 				}
 				if port != "22" {
 					overrideConfig.Port = port
+				}
+				if !keepalive {
+					overrideConfig.KeepaliveInterval = 0
 				}
 				client, err = ssh.NewClientFromSSHConfigWithLogger(host, overrideConfig, logger)
 				if err != nil {
@@ -136,12 +142,16 @@ func newUpCmd() *cobra.Command {
 				}
 
 				sshConfig := &ssh.Config{
-					Host:     host,
-					Port:     port,
-					Username: user,
-					KeyPath:  keyPath,
-					Password: password,
-					Timeout:  time.Duration(timeout) * time.Second,
+					Host:              host,
+					Port:              port,
+					Username:          user,
+					KeyPath:           keyPath,
+					Password:          password,
+					Timeout:           time.Duration(timeout) * time.Second,
+					KeepaliveInterval: time.Duration(keepaliveInt) * time.Second,
+				}
+				if !keepalive {
+					sshConfig.KeepaliveInterval = 0
 				}
 
 				client = ssh.NewClientWithLogger(sshConfig, logger)
@@ -154,6 +164,10 @@ func newUpCmd() *cobra.Command {
 			}
 			defer client.Close()
 			logger.Infof("Connected successfully")
+
+			if keepalive {
+				logger.Infof("Keepalive enabled (interval: %ds)", keepaliveInt)
+			}
 
 			if idePort == 0 {
 				idePort = 10081
@@ -173,19 +187,23 @@ func newUpCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&forwards, "forward", []string{}, "Ports to forward (e.g., 3000, 8080:80)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Auto-detect and forward web service ports")
 	cmd.Flags().IntVar(&timeout, "timeout", 30, "SSH connection timeout in seconds")
+	cmd.Flags().BoolVar(&keepalive, "keepalive", true, "Enable SSH connection keepalive")
+	cmd.Flags().IntVar(&keepaliveInt, "keepalive-interval", 30, "Keepalive interval in seconds")
 
 	return cmd
 }
 
 func newForwardCmd() *cobra.Command {
 	var (
-		user     string
-		port     string
-		keyPath  string
-		password string
-		forwards []string
-		auto     bool
-		timeout  int
+		user             string
+		port             string
+		keyPath          string
+		password         string
+		forwards         []string
+		auto             bool
+		timeout          int
+		keepalive        bool
+		keepaliveInt     int
 	)
 
 	cmd := &cobra.Command{
@@ -193,11 +211,9 @@ func newForwardCmd() *cobra.Command {
 		Short: "Forward ports from remote host to local machine",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// 获取logger
 			logger := logging.GetGlobalLogger()
 			host := args[0]
 
-			// Parse host if it contains user@host format
 			if strings.Contains(host, "@") {
 				parts := strings.Split(host, "@")
 				if len(parts) == 2 {
@@ -209,35 +225,33 @@ func newForwardCmd() *cobra.Command {
 			var client *ssh.Client
 			var err error
 
-			// 检查是否是SSH配置文件中的主机
 			parser := ssh.NewSSHConfigParser()
 			_, sshErr := parser.GetHost(host)
 			if sshErr == nil {
-				// 从SSH配置文件创建客户端，使用命令行参数覆盖
 				overrideConfig := &ssh.Config{
 					Host: host,
 
-					Username: user,
-					KeyPath:  keyPath,
-					Password: password,
-					Timeout:  time.Duration(timeout) * time.Second,
+					Username:          user,
+					KeyPath:           keyPath,
+					Password:          password,
+					Timeout:           time.Duration(timeout) * time.Second,
+					KeepaliveInterval: time.Duration(keepaliveInt) * time.Second,
 				}
-				// 只有当用户显式提供了-p参数时才覆盖端口
 				if port != "22" {
 					overrideConfig.Port = port
+				}
+				if !keepalive {
+					overrideConfig.KeepaliveInterval = 0
 				}
 				client, err = ssh.NewClientFromSSHConfigWithLogger(host, overrideConfig, logger)
 				if err != nil {
 					return fmt.Errorf("failed to create client from SSH config: %w", err)
 				}
 			} else {
-				// 检查是否是特殊主机模式的错误
 				if strings.Contains(sshErr.Error(), "is a special pattern") {
 					return fmt.Errorf("cannot connect to %s: %v", host, sshErr)
 				}
 
-				// 如果不是SSH配置文件中的主机，使用传统方式
-				// Parse host if it contains user@host format
 				if strings.Contains(host, "@") {
 					parts := strings.Split(host, "@")
 					if len(parts) == 2 {
@@ -246,19 +260,21 @@ func newForwardCmd() *cobra.Command {
 					}
 				}
 
-				// 检查必需参数
 				if user == "" {
 					return fmt.Errorf("username is required when host is not in SSH config file. Use -u flag or user@host format")
 				}
 
-				// Create SSH config
 				sshConfig := &ssh.Config{
-					Host:     host,
-					Port:     port,
-					Username: user,
-					KeyPath:  keyPath,
-					Password: password,
-					Timeout:  time.Duration(timeout) * time.Second,
+					Host:              host,
+					Port:              port,
+					Username:          user,
+					KeyPath:           keyPath,
+					Password:          password,
+					Timeout:           time.Duration(timeout) * time.Second,
+					KeepaliveInterval: time.Duration(keepaliveInt) * time.Second,
+				}
+				if !keepalive {
+					sshConfig.KeepaliveInterval = 0
 				}
 
 				client = ssh.NewClientWithLogger(sshConfig, logger)
@@ -271,10 +287,12 @@ func newForwardCmd() *cobra.Command {
 			defer client.Close()
 			logger.Infof("Connected successfully")
 
-			// Create tunnel manager
+			if keepalive {
+				logger.Infof("Keepalive enabled (interval: %ds)", keepaliveInt)
+			}
+
 			tunnelManager := tunnel.NewTunnelManagerWithLogger(logger)
 
-			// Parse forward ports
 			var forwardConfigs []tunnel.ForwardConfig
 			if auto {
 				forwardConfigs = append(forwardConfigs, tunnel.ForwardConfig{AutoDetect: true})
@@ -282,7 +300,6 @@ func newForwardCmd() *cobra.Command {
 				for _, forward := range forwards {
 					parts := strings.Split(forward, ":")
 					if len(parts) == 1 {
-						// Single port: forward remote port to same local port
 						port, err := strconv.Atoi(parts[0])
 						if err != nil {
 							return fmt.Errorf("invalid port: %s", parts[0])
@@ -292,7 +309,6 @@ func newForwardCmd() *cobra.Command {
 							RemotePort: port,
 						})
 					} else if len(parts) == 2 {
-						// Local:Remote port mapping
 						localPort, err := strconv.Atoi(parts[0])
 						if err != nil {
 							return fmt.Errorf("invalid local port: %s", parts[0])
@@ -309,13 +325,16 @@ func newForwardCmd() *cobra.Command {
 				}
 			}
 
-			// Create port forwards
 			_, err = tunnel.CreatePortForwards(client, forwardConfigs, tunnelManager)
 			if err != nil {
 				return fmt.Errorf("failed to create port forwards: %w", err)
 			}
 
-			// List active tunnels
+			client.SetReconnectHandler(func() {
+				logger.Infof("Connection re-established, updating tunnels...")
+				tunnelManager.UpdateSSHClient(client)
+			})
+
 			tunnels := tunnelManager.ListTunnels()
 			logger.Infof("Active port forwards:")
 			for name, info := range tunnels {
@@ -324,7 +343,6 @@ func newForwardCmd() *cobra.Command {
 
 			logger.Infof("Press Ctrl+C to stop...")
 
-			// Wait for interrupt
 			select {
 			case <-cmd.Context().Done():
 				logger.Infof("Stopping...")
@@ -341,6 +359,8 @@ func newForwardCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&forwards, "ports", []string{}, "Ports to forward (e.g., 3000, 8080:80)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Auto-detect and forward web service ports")
 	cmd.Flags().IntVar(&timeout, "timeout", 30, "SSH connection timeout in seconds")
+	cmd.Flags().BoolVar(&keepalive, "keepalive", true, "Enable SSH connection keepalive")
+	cmd.Flags().IntVar(&keepaliveInt, "keepalive-interval", 30, "Keepalive interval in seconds")
 
 	return cmd
 }

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -288,6 +288,11 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 		return fmt.Errorf("failed to create port forwards: %w", err)
 	}
 
+	client.SetReconnectHandler(func() {
+		logger.Infof("Connection re-established, updating tunnels...")
+		tunnelManager.UpdateSSHClient(client)
+	})
+
 	tunnels := tunnelManager.ListTunnels()
 	logger.Infof("Active port forwards:")
 	for name, info := range tunnels {

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Sylens Wong <qiumin14@163.com>"]
 channels = ["conda-forge"]
 name = "DevSSH"
 platforms = ["linux-aarch64", "linux-64", "osx-arm64", "osx-64"]
-version = "0.1.7"
+version = "0.1.8"
 preview = ["pixi-build"]
 
 [tasks.clean_linux]
@@ -56,7 +56,7 @@ go = ">=1.25.4,<2"
 
 [package]
 name = "DevSSH"
-version = "0.1.7"
+version = "0.1.8"
 
 [package.build.backend]
 name = "pixi-build-rattler-build"

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"devssh/pkg/logging"
@@ -14,19 +16,32 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
+const (
+	defaultKeepaliveInterval = 30 * time.Second
+	healthCheckTimeout       = 10 * time.Second
+)
+
 type Config struct {
-	Host     string
-	Port     string
-	Username string
-	KeyPath  string
-	Password string
-	Timeout  time.Duration
+	Host              string
+	Port              string
+	Username          string
+	KeyPath           string
+	Password          string
+	Timeout           time.Duration
+	KeepaliveInterval time.Duration
 }
 
 type Client struct {
 	config *Config
 	client *ssh.Client
 	logger log.Logger
+
+	mu              sync.Mutex
+	connected       atomic.Bool
+	keepaliveStop   chan struct{}
+	keepaliveWg     sync.WaitGroup
+	onReconnect     func()
+	healthCheckFn   func() bool
 }
 
 func NewClient(config *Config) *Client {
@@ -42,6 +57,33 @@ func NewClientWithLogger(config *Config, logger log.Logger) *Client {
 		config: config,
 		logger: logger,
 	}
+}
+
+func (c *Client) SetReconnectHandler(handler func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onReconnect = handler
+}
+
+func (c *Client) EnableKeepalive() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.config.KeepaliveInterval <= 0 {
+		c.config.KeepaliveInterval = defaultKeepaliveInterval
+	}
+}
+
+func (c *Client) DisableKeepalive() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.keepaliveStop = nil
+	c.config.KeepaliveInterval = 0
+}
+
+func (c *Client) SetHealthCheckFn(fn func() bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.healthCheckFn = fn
 }
 
 // NewClientFromSSHConfig 从SSH配置文件创建客户端
@@ -77,15 +119,40 @@ func NewClientFromSSHConfigWithLogger(hostName string, overrideConfig *Config, l
 		if overrideConfig.Timeout > 0 {
 			config.Timeout = overrideConfig.Timeout
 		}
+		if overrideConfig.KeepaliveInterval > 0 {
+			config.KeepaliveInterval = overrideConfig.KeepaliveInterval
+		}
 	}
 
 	return NewClientWithLogger(config, logger), nil
 }
 
 func (c *Client) Connect() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	client, err := c.dial()
+	if err != nil {
+		return err
+	}
+
+	c.client = client
+	c.connected.Store(true)
+	c.logger.Infof("SSH connection established successfully")
+
+	// 启动心跳检测
+	interval := c.config.KeepaliveInterval
+	if interval > 0 {
+		c.startKeepaliveLocked(interval)
+	}
+
+	return nil
+}
+
+func (c *Client) dial() (*ssh.Client, error) {
 	authMethods, err := c.getAuthMethods()
 	if err != nil {
-		return fmt.Errorf("failed to get auth methods: %w", err)
+		return nil, fmt.Errorf("failed to get auth methods: %w", err)
 	}
 
 	sshConfig := &ssh.ClientConfig{
@@ -106,7 +173,6 @@ func (c *Client) Connect() error {
 	address := net.JoinHostPort(c.config.Host, c.config.Port)
 	c.logger.Infof("Attempting to connect to %s as user '%s' with timeout %v", address, c.config.Username, c.config.Timeout)
 
-	// 显示使用的认证方法
 	if c.config.Password != "" {
 		c.logger.Infof("Using password authentication (password provided)")
 	}
@@ -114,37 +180,141 @@ func (c *Client) Connect() error {
 		c.logger.Infof("Using private key: %s", c.config.KeyPath)
 	}
 
-	// 先测试TCP连接
 	tcpConn, tcpErr := net.DialTimeout("tcp", address, c.config.Timeout)
 	if tcpErr != nil {
-		return fmt.Errorf("TCP connection failed: %w", tcpErr)
+		return nil, fmt.Errorf("TCP connection failed: %w", tcpErr)
 	}
 	tcpConn.Close()
 	c.logger.Infof("TCP connection successful, attempting SSH handshake...")
 
-	client, err := ssh.Dial("tcp", address, sshConfig)
+	cli, err := ssh.Dial("tcp", address, sshConfig)
 	if err != nil {
-		return fmt.Errorf("failed to dial SSH: %w", err)
+		return nil, fmt.Errorf("failed to dial SSH: %w", err)
+	}
+	return cli, nil
+}
+
+func (c *Client) startKeepaliveLocked(interval time.Duration) {
+	if c.keepaliveStop != nil {
+		return
+	}
+	c.keepaliveStop = make(chan struct{})
+	c.keepaliveWg.Add(1)
+	go c.keepaliveLoop(interval)
+}
+
+func (c *Client) keepaliveLoop(interval time.Duration) {
+	defer c.keepaliveWg.Done()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.keepaliveStop:
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			currentClient := c.client
+			c.mu.Unlock()
+
+			if currentClient == nil {
+				continue
+			}
+
+			if !c.checkHealth(currentClient) {
+				c.logger.Warnf("Connection health check failed, attempting reconnect...")
+				if err := c.reconnect(); err != nil {
+					c.logger.Errorf("Reconnect failed: %v", err)
+					continue
+				}
+				c.logger.Infof("Reconnected successfully")
+
+				c.mu.Lock()
+				handler := c.onReconnect
+				c.mu.Unlock()
+
+				if handler != nil {
+					handler()
+				}
+			}
+		}
+	}
+}
+
+func (c *Client) checkHealth(cli *ssh.Client) bool {
+	if c.healthCheckFn != nil {
+		return c.healthCheckFn()
 	}
 
-	c.client = client
-	c.logger.Infof("SSH connection established successfully")
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := cli.SendRequest("keepalive@openssh.com", true, nil)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		return err == nil
+	case <-time.After(healthCheckTimeout):
+		return false
+	}
+}
+
+func (c *Client) reconnect() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	oldClient := c.client
+	c.client = nil
+	c.connected.Store(false)
+
+	if oldClient != nil {
+		oldClient.Close()
+	}
+
+	newClient, err := c.dial()
+	if err != nil {
+		return fmt.Errorf("reconnect failed: %w", err)
+	}
+
+	c.client = newClient
+	c.connected.Store(true)
 	return nil
 }
 
 func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.keepaliveStop != nil {
+		close(c.keepaliveStop)
+		c.keepaliveStop = nil
+	}
+	c.keepaliveWg.Wait()
+
+	c.connected.Store(false)
 	if c.client != nil {
-		return c.client.Close()
+		err := c.client.Close()
+		c.client = nil
+		return err
 	}
 	return nil
 }
 
+func (c *Client) getClient() *ssh.Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.client
+}
+
 func (c *Client) RunCommand(cmd string) (string, error) {
-	if c.client == nil {
+	cli := c.getClient()
+	if cli == nil {
 		return "", fmt.Errorf("not connected")
 	}
 
-	session, err := c.client.NewSession()
+	session, err := cli.NewSession()
 	if err != nil {
 		return "", fmt.Errorf("failed to create session: %w", err)
 	}
@@ -159,11 +329,12 @@ func (c *Client) RunCommand(cmd string) (string, error) {
 }
 
 func (c *Client) RunCommandWithOutput(cmd string, stdout, stderr io.Writer) error {
-	if c.client == nil {
+	cli := c.getClient()
+	if cli == nil {
 		return fmt.Errorf("not connected")
 	}
 
-	session, err := c.client.NewSession()
+	session, err := cli.NewSession()
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)
 	}
@@ -176,10 +347,11 @@ func (c *Client) RunCommandWithOutput(cmd string, stdout, stderr io.Writer) erro
 }
 
 func (c *Client) NewSession() (*ssh.Session, error) {
-	if c.client == nil {
+	cli := c.getClient()
+	if cli == nil {
 		return nil, fmt.Errorf("not connected")
 	}
-	return c.client.NewSession()
+	return cli.NewSession()
 }
 
 func (c *Client) getAuthMethods() ([]ssh.AuthMethod, error) {
@@ -265,15 +437,16 @@ func (c *Client) getAuthMethods() ([]ssh.AuthMethod, error) {
 }
 
 func (c *Client) IsConnected() bool {
-	return c.client != nil
+	return c.connected.Load()
 }
 
 func (c *Client) GetClient() *ssh.Client {
-	return c.client
+	return c.getClient()
 }
 
-// SetLogger 设置logger
 func (c *Client) SetLogger(logger log.Logger) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.logger = logger
 }
 
@@ -281,7 +454,6 @@ func (c *Client) GetConfig() *Config {
 	return c.config
 }
 
-// NewSCPClient 创建SCP客户端
 func (c *Client) NewSCPClient() *SCPClient {
 	return NewSCPClient(c)
 }

--- a/pkg/ssh/tunnel.go
+++ b/pkg/ssh/tunnel.go
@@ -29,7 +29,15 @@ type Tunnel struct {
 }
 
 func (t *Tunnel) GetConfig() *TunnelConfig {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return t.config
+}
+
+func (t *Tunnel) SetSSHClient(client *ssh.Client) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.client = client
 }
 
 const (

--- a/pkg/tunnel/manager.go
+++ b/pkg/tunnel/manager.go
@@ -149,6 +149,16 @@ func (m *TunnelManager) GetTunnel(name string) (*ssh.Tunnel, bool) {
 	return tunnel, exists
 }
 
+func (m *TunnelManager) UpdateSSHClient(client *ssh.Client) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, tunnel := range m.tunnels {
+		tunnel.SetSSHClient(client.GetClient())
+	}
+	m.logger.Infof("Updated all tunnels with new SSH client")
+}
+
 type ForwardConfig struct {
 	LocalPort  int
 	RemotePort int

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,6 +1,6 @@
 package:
   name: devssh
-  version: 0.1.7
+  version: 0.1.8
 
 source:
   path: .


### PR DESCRIPTION
## 变更内容

为 DevSSH 添加 SSH 连接心跳检测与自动重连功能（[SIL-59](mention://issue/ae06c413-b636-4110-9d10-c8b7f9de92e2)）。

### 改动文件

| 文件 | 改动 |
|------|------|
| `pkg/ssh/client.go` | 新增心跳检测 goroutine、自动重连、线程安全连接访问 |
| `pkg/ssh/tunnel.go` | 新增 `SetSSHClient()` 支持重连后更新隧道 |
| `pkg/tunnel/manager.go` | 新增 `UpdateSSHClient()` 批量更新所有隧道 |
| `cmd/devssh/main.go` | `up`/`forward` 命令新增 `--keepalive`/`--keepalive-interval` 参数 |
| `cmd/devssh/up.go` | 注册重连处理器，重连后自动恢复隧道 |

### 实现机制

1. **心跳检测**: 后台 goroutine 定期发送 `keepalive@openssh.com` 请求（10s 超时判定断连）
2. **自动重连**: 检测到断连后自动重新发起 SSH 连接，复用原认证方式
3. **隧道恢复**: 重连成功后自动更新所有端口转发隧道指向新连接
4. **线程安全**: `sync.Mutex` + `atomic.Bool` 保护连接访问

### 使用

默认启用（30s 间隔），无需额外操作。可选：
- `--keepalive=false` 关闭
- `--keepalive-interval=60` 自定义间隔