### PR TITLE
fix: skip binary relocation for static Go binary to fix install_name_tool error

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -10,6 +10,8 @@ build:
   number: 1
   script: |
     go build -o $PREFIX/bin/devssh ./cmd/devssh
+  dynamic_linking:
+    binary_relocation: false
 
 requirements:
   build:


### PR DESCRIPTION
## 问题

Linux 下使用 `pixi publish` 交叉编译 `osx-64` / `osx-arm64` 时报错：



rattler-build 在打包阶段会对 Mach-O 二进制调用 `install_name_tool`，但该工具不存在于 Linux 上。

DevSSH 使用 `go-nocgo` + `CGO_ENABLED=0`，生成的二进制完全静态链接，无需重定位。

## 修复

在 `recipe.yaml` 中新增 `dynamic_linking.binary_relocation: false`，跳过后处理的二进制重定位步骤。

## 关联 Issue

SIL-61