### PR TITLE
feat: rollback VSCodium to 1.116.02821 and add remote version detection

### DIFF
--- a/cmd/devssh/agent.go
+++ b/cmd/devssh/agent.go
@@ -25,7 +25,7 @@ Commands:
 
 Examples:
   devssh agent install
-  devssh agent install --version 1.121.03429
+  devssh agent install --version 1.116.02821
   devssh agent install --local-tar /path/to/vscodium-reh-web.tar.gz
   devssh agent start --port 10081
   devssh agent stop
@@ -72,7 +72,7 @@ If already installed, this command will be skipped.`,
 			logging.Infof("Installing VSCode...")
 
 			if localTar != "" {
-				if err := runner.InstallFromTar(localTar); err != nil {
+				if err := runner.InstallFromTar(localTar, version); err != nil {
 					return fmt.Errorf("failed to install VSCode from local tar: %w", err)
 				}
 			} else {
@@ -86,7 +86,7 @@ If already installed, this command will be skipped.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&version, "version", "1.121.03429", "VSCode version to install")
+	cmd.Flags().StringVar(&version, "version", "1.116.02821", "VSCode version to install")
 	cmd.Flags().StringVar(&localTar, "local-tar", "", "Path to local tar.gz file (use this instead of downloading)")
 
 	return cmd

--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -183,7 +183,7 @@ func newUpCmd() *cobra.Command {
 	cmd.Flags().StringVar(&password, "password", "", "SSH password")
 	cmd.Flags().StringVar(&ideType, "ide", "vscode", "Web IDE type (vscode, code-server)")
 	cmd.Flags().IntVar(&idePort, "ide-port", 10081, "Port for IDE")
-	cmd.Flags().StringVar(&version, "version", "1.121.03429", "IDE version")
+	cmd.Flags().StringVar(&version, "version", "1.116.02821", "IDE version")
 	cmd.Flags().StringSliceVar(&forwards, "forward", []string{}, "Ports to forward (e.g., 3000, 8080:80)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Auto-detect and forward web service ports")
 	cmd.Flags().IntVar(&timeout, "timeout", 30, "SSH connection timeout in seconds")

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -165,13 +165,36 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	}
 
 	logger.Infof("Checking VSCode installation on remote...")
-	vscodeCheckCmd := "test -f ~/.devssh/vscodium/bin/codium-server && echo 'installed' || echo 'not_installed'"
-	checkOutput, checkErr := client.RunCommand(vscodeCheckCmd)
+	checkCmd := "test -f ~/.devssh/vscodium/bin/codium-server && echo 'installed' || echo 'not_installed'"
+	checkOutput, checkErr := client.RunCommand(checkCmd)
 	if checkErr != nil {
 		return fmt.Errorf("failed to check remote VSCode: %w", checkErr)
 	}
 
+	if version == "" {
+		version = "1.116.02821"
+	}
+
+	needsReinstall := false
 	if strings.Contains(checkOutput, "not_installed") {
+		needsReinstall = true
+	} else {
+		versionCheckCmd := "cat ~/.devssh/vscodium/version 2>/dev/null || echo 'unknown'"
+		versionOutput, _ := client.RunCommand(versionCheckCmd)
+		installedVersion := strings.TrimSpace(versionOutput)
+		if installedVersion != version {
+			logger.Infof("VSCode version mismatch: installed=%s, expected=%s", installedVersion, version)
+			needsReinstall = true
+		}
+	}
+
+	if needsReinstall {
+		logger.Infof("Stopping VSCode if running...")
+		client.RunCommand("~/.devssh/bin/devssh agent stop")
+
+		logger.Infof("Removing existing VSCodium installation...")
+		client.RunCommand("rm -rf ~/.devssh/vscodium")
+
 		logger.Infof("Downloading VSCode %s for %s/%s...", version, remoteOS, remoteArch)
 		vscodePath, err := downloadVSCodeLocal(version, remoteOS, remoteArch, logger)
 		if err != nil {
@@ -184,7 +207,8 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 		}
 
 		logger.Infof("Installing VSCodium on remote...")
-		if _, err := runRemoteAgentCommand(client, "install --local-tar ~/.devssh/vscodium-reh-web.tar.gz"); err != nil {
+		installCmd := fmt.Sprintf("install --local-tar ~/.devssh/vscodium-reh-web.tar.gz --version %s", version)
+		if _, err := runRemoteAgentCommand(client, installCmd); err != nil {
 			return fmt.Errorf("failed to install VSCode: %w", err)
 		}
 	} else {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -20,15 +20,16 @@ import (
 )
 
 const (
-	DefaultVersion = "1.121.03429"
+	DefaultVersion = "1.116.02821"
 )
 
 type Runner struct {
-	workDir    string
-	logFile    string
-	vscodiumDir string
-	serverPath string
-	serverPID  int
+	workDir        string
+	logFile        string
+	vscodiumDir    string
+	serverPath     string
+	versionFile    string
+	serverPID      int
 }
 
 func NewRunner() (*Runner, error) {
@@ -50,6 +51,7 @@ func NewRunner() (*Runner, error) {
 		logFile:     logFile,
 		vscodiumDir: vscodiumDir,
 		serverPath:  filepath.Join(vscodiumDir, "bin", "codium-server"),
+		versionFile: filepath.Join(vscodiumDir, "version"),
 	}, nil
 }
 
@@ -84,7 +86,21 @@ func (r *Runner) Install(version string) error {
 
 	os.Remove(downloadPath)
 
+	r.saveVersion(version)
+
 	return nil
+}
+
+func (r *Runner) saveVersion(version string) {
+	os.WriteFile(r.versionFile, []byte(version), 0644)
+}
+
+func (r *Runner) GetInstalledVersion() string {
+	data, err := os.ReadFile(r.versionFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func (r *Runner) Start(port int) error {
@@ -356,7 +372,7 @@ func getHomeDir() (string, error) {
 	return usr.HomeDir, nil
 }
 
-func (r *Runner) InstallFromTar(tarPath string) error {
+func (r *Runner) InstallFromTar(tarPath string, version string) error {
 	if r.IsInstalled() {
 		logging.Infof("VSCode is already installed")
 		return nil
@@ -370,6 +386,10 @@ func (r *Runner) InstallFromTar(tarPath string) error {
 
 	if err := r.extract(tarPath); err != nil {
 		return fmt.Errorf("failed to extract: %w", err)
+	}
+
+	if version != "" {
+		r.saveVersion(version)
 	}
 
 	logging.Infof("VSCode installed successfully")

--- a/pkg/download/local_downloader.go
+++ b/pkg/download/local_downloader.go
@@ -52,7 +52,7 @@ func (d *LocalDownloader) Download(url string) (string, error) {
 
 func (d *LocalDownloader) DownloadVSCode(version, os, arch string) (string, error) {
 	if version == "" {
-		version = "1.121.03429"
+		version = "1.116.02821"
 	}
 
 	url := d.GetVSCodeDownloadURL(version, os, arch)


### PR DESCRIPTION
## 变更内容

### 1. VSCodium 版本回退到 1.116.02821
将默认版本从 `1.121.03429` 改为 `1.116.02821`（1.121 图片查看有问题）。

### 2. 增加 VSCodium 远程版本检测机制
- 安装时记录版本号到 `~/.devssh/vscodium/version`
- 远程连接时检测已安装版本，与期望版本对比
- 版本不匹配时自动：停止进程 → 删除旧版本 → 下载安装指定版本

Closes #[SIL-63]