### PR TITLE
fix: 修复远程目标为 macOS 时反复下载 devssh 和 codium-server 的问题

### DIFF
--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -187,7 +187,7 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	if strings.Contains(checkOutput, "not_installed") {
 		needsReinstall = true
 	} else {
-		versionCheckCmd := "cat \"$HOME/.devssh/vscodium/version\" 2>/dev/null || echo 'unknown'"
+		versionCheckCmd := "grep -o '\"version\":\"[^\"]*\"' \"$HOME/.devssh/vscodium/product.json\" 2>/dev/null | cut -d'\"' -f4 || echo 'unknown'"
 		versionOutput, _ := client.RunCommand(versionCheckCmd)
 		installedVersion := strings.TrimSpace(versionOutput)
 		if installedVersion != version {
@@ -220,16 +220,6 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 		installCmd := fmt.Sprintf("install --local-tar \"$HOME/.devssh/vscodium-reh-web.tar.gz\" --version %s", version)
 		if _, err := runRemoteAgentCommand(client, installCmd); err != nil {
 			return fmt.Errorf("failed to install VSCode: %w", err)
-		}
-
-		postCheckCmd := "test -f \"$HOME/.devssh/vscodium/version\" && echo 'ok' || echo 'missing'"
-		postOutput, postErr := client.RunCommand(postCheckCmd)
-		if postErr != nil || strings.Contains(postOutput, "missing") {
-			logger.Warnf("VSCode version file is still missing after install, trying to create it manually")
-			writeVersionCmd := fmt.Sprintf("echo '%s' > \"$HOME/.devssh/vscodium/version\"", version)
-			if _, err := client.RunCommand(writeVersionCmd); err != nil {
-				return fmt.Errorf("failed to write version file: %w", err)
-			}
 		}
 	} else {
 		logger.Infof("VSCode is already installed, skipping installation")

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -194,9 +194,12 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	if strings.Contains(checkOutput, "not_installed") {
 		needsReinstall = true
 	} else {
-		versionCheckCmd := "grep -o '\"version\":\"[^\"]*\"' \"$HOME/.devssh/vscodium/product.json\" 2>/dev/null | cut -d'\"' -f4 || echo 'unknown'"
+		versionCheckCmd := "grep -o '\"version\": *\"[^\"]*\"' \"$HOME/.devssh/vscodium/product.json\" 2>/dev/null | cut -d'\"' -f4"
 		versionOutput, _ := client.RunCommand(versionCheckCmd)
 		installedVersion := strings.TrimSpace(versionOutput)
+		if installedVersion == "" {
+			installedVersion = "unknown"
+		}
 		if installedVersion != version {
 			logger.Infof("VSCode version mismatch: installed=%s, expected=%s", installedVersion, version)
 			needsReinstall = true

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -162,14 +162,21 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	logger.Infof("Target platform: %s/%s", remoteOS, remoteArch)
 
 	logger.Infof("Checking devssh on remote...")
-	exists, remoteVersion, _ := checkRemoteDevSSH(client)
+	exists, remoteVersion, err := checkRemoteDevSSH(client)
+	if err != nil {
+		logger.Debugf("devssh check error: %v", err)
+	}
+	if !exists {
+		logger.Infof("devssh binary not found on remote, deploying %s...", GetVersion())
+	} else if remoteVersion != GetVersion() {
+		logger.Infof("devssh version mismatch: remote=%s, expected=%s, deploying...", remoteVersion, GetVersion())
+	} else {
+		logger.Infof("devssh %s is already installed", remoteVersion)
+	}
 	if !exists || remoteVersion != GetVersion() {
-		logger.Infof("Deploying devssh %s...", GetVersion())
 		if err := deployDevSSH(client, GetVersion(), logger); err != nil {
 			return fmt.Errorf("failed to deploy devssh: %w", err)
 		}
-	} else {
-		logger.Infof("devssh %s is already installed", remoteVersion)
 	}
 
 	logger.Infof("Checking VSCode installation on remote...")

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -194,7 +194,7 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	if strings.Contains(checkOutput, "not_installed") {
 		needsReinstall = true
 	} else {
-		versionCheckCmd := "grep -o '\"version\": *\"[^\"]*\"' \"$HOME/.devssh/vscodium/product.json\" 2>/dev/null | cut -d'\"' -f4"
+		versionCheckCmd := "awk -F'\"' '/\"version\"[[:space:]]*:[[:space:]]*\"/{v=$4} END{print v}' \"$HOME/.devssh/vscodium/product.json\" 2>/dev/null"
 		versionOutput, _ := client.RunCommand(versionCheckCmd)
 		installedVersion := strings.TrimSpace(versionOutput)
 		if installedVersion == "" {

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -24,15 +24,21 @@ func uploadToRemote(client *ssh.Client, localPath, remotePath string) error {
 }
 
 func checkRemoteDevSSH(client *ssh.Client) (exists bool, version string, err error) {
-	cmd := "test -f ~/.devssh/bin/devssh && ~/.devssh/bin/devssh --version 2>/dev/null || echo 'not_found'"
-	output, err := client.RunCommand(cmd)
+	existsCmd := "test -f \"$HOME/.devssh/bin/devssh\""
+	if _, err := client.RunCommand(existsCmd); err != nil {
+		return false, "", nil
+	}
+
+	versionCmd := "\"$HOME/.devssh/bin/devssh\" --version 2>/dev/null || echo 'unknown'"
+	output, err := client.RunCommand(versionCmd)
 	if err != nil {
-		return false, "", nil
+		return true, "", nil
 	}
-	if strings.Contains(output, "not_found") {
-		return false, "", nil
-	}
+
 	version = strings.TrimSpace(output)
+	if version == "unknown" {
+		return true, "", nil
+	}
 	version = strings.TrimPrefix(version, "devssh version ")
 	return true, version, nil
 }
@@ -95,18 +101,20 @@ func deployDevSSH(client *ssh.Client, version string, logger log.Logger) error {
 	defer os.Remove(localPath)
 
 	logger.Infof("Uploading devssh to remote...")
-	if err := uploadToRemote(client, localPath, "~/.devssh/bin/devssh"); err != nil {
+	if err := uploadToRemote(client, localPath, "$HOME/.devssh/bin/devssh"); err != nil {
 		return fmt.Errorf("failed to upload devssh: %w", err)
 	}
 
 	logger.Infof("Setting executable permissions...")
-	client.RunCommand("chmod +x ~/.devssh/bin/devssh")
+	if _, err := client.RunCommand("chmod +x \"$HOME/.devssh/bin/devssh\""); err != nil {
+		logger.Warnf("Failed to set executable permissions: %v", err)
+	}
 
 	return nil
 }
 
 func runRemoteAgentCommand(client *ssh.Client, args string) (string, error) {
-	cmd := fmt.Sprintf("~/.devssh/bin/devssh agent %s", args)
+	cmd := fmt.Sprintf("\"$HOME/.devssh/bin/devssh\" agent %s", args)
 	output, err := client.RunCommand(cmd)
 	if err != nil {
 		return output, fmt.Errorf("failed to run agent command: %w, output: %s", err, output)
@@ -165,7 +173,7 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	}
 
 	logger.Infof("Checking VSCode installation on remote...")
-	checkCmd := "test -f ~/.devssh/vscodium/bin/codium-server && echo 'installed' || echo 'not_installed'"
+	checkCmd := "test -f \"$HOME/.devssh/vscodium/bin/codium-server\" && echo 'installed' || echo 'not_installed'"
 	checkOutput, checkErr := client.RunCommand(checkCmd)
 	if checkErr != nil {
 		return fmt.Errorf("failed to check remote VSCode: %w", checkErr)
@@ -179,7 +187,7 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	if strings.Contains(checkOutput, "not_installed") {
 		needsReinstall = true
 	} else {
-		versionCheckCmd := "cat ~/.devssh/vscodium/version 2>/dev/null || echo 'unknown'"
+		versionCheckCmd := "cat \"$HOME/.devssh/vscodium/version\" 2>/dev/null || echo 'unknown'"
 		versionOutput, _ := client.RunCommand(versionCheckCmd)
 		installedVersion := strings.TrimSpace(versionOutput)
 		if installedVersion != version {
@@ -190,10 +198,10 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 
 	if needsReinstall {
 		logger.Infof("Stopping VSCode if running...")
-		client.RunCommand("~/.devssh/bin/devssh agent stop")
+		client.RunCommand("\"$HOME/.devssh/bin/devssh\" agent stop")
 
 		logger.Infof("Removing existing VSCodium installation...")
-		client.RunCommand("rm -rf ~/.devssh/vscodium")
+		client.RunCommand("rm -rf \"$HOME/.devssh/vscodium\"")
 
 		logger.Infof("Downloading VSCode %s for %s/%s...", version, remoteOS, remoteArch)
 		vscodePath, err := downloadVSCodeLocal(version, remoteOS, remoteArch, logger)
@@ -202,12 +210,12 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 		}
 
 		logger.Infof("Uploading VSCodium to remote...")
-		if err := uploadToRemote(client, vscodePath, "~/.devssh/vscodium-reh-web.tar.gz"); err != nil {
+		if err := uploadToRemote(client, vscodePath, "$HOME/.devssh/vscodium-reh-web.tar.gz"); err != nil {
 			return fmt.Errorf("failed to upload VSCodium: %w", err)
 		}
 
 		logger.Infof("Installing VSCodium on remote...")
-		installCmd := fmt.Sprintf("install --local-tar ~/.devssh/vscodium-reh-web.tar.gz --version %s", version)
+		installCmd := fmt.Sprintf("install --local-tar \"$HOME/.devssh/vscodium-reh-web.tar.gz\" --version %s", version)
 		if _, err := runRemoteAgentCommand(client, installCmd); err != nil {
 			return fmt.Errorf("failed to install VSCode: %w", err)
 		}
@@ -219,14 +227,14 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	currentPort := 0
 	isRunning := false
 
-	vscodeCheckCmdStr := "~/.devssh/bin/devssh agent is-running"
+	vscodeCheckCmdStr := "\"$HOME/.devssh/bin/devssh\" agent is-running"
 	checkOutput, cmdErr := client.RunCommand(vscodeCheckCmdStr)
 	if cmdErr == nil && strings.Contains(checkOutput, "running") {
 		isRunning = true
 	}
 
 	if isRunning {
-		vscodePortCmdStr := "~/.devssh/bin/devssh agent get-port"
+		vscodePortCmdStr := "\"$HOME/.devssh/bin/devssh\" agent get-port"
 		portOutput, cmdErr := client.RunCommand(vscodePortCmdStr)
 		if cmdErr == nil {
 			portStr := strings.TrimSpace(portOutput)
@@ -241,9 +249,9 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	} else if currentPort == 0 {
 		logger.Infof("VSCode is running but port is unknown, restarting with specified port %d...", idePort)
 		logger.Infof("Stopping VSCode...")
-		_, cmdErr := client.RunCommand("~/.devssh/bin/devssh agent stop")
+		_, cmdErr := client.RunCommand("\"$HOME/.devssh/bin/devssh\" agent stop")
 		if cmdErr != nil {
-			pidCmd := "cat ~/.devssh/agent.pid | grep pid= | cut -d= -f2"
+			pidCmd := "cat \"$HOME/.devssh/agent.pid\" | grep pid= | cut -d= -f2"
 			pidOutput, _ := client.RunCommand(pidCmd)
 			return fmt.Errorf("failed to stop VSCode (pid: %s). Please manually kill the process and try again", strings.TrimSpace(pidOutput))
 		}
@@ -251,9 +259,9 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	} else if currentPort > 0 && currentPort != idePort {
 		logger.Warnf("VSCode is running on port %d, but requested port is %d", currentPort, idePort)
 		logger.Infof("Stopping VSCode...")
-		_, cmdErr := client.RunCommand("~/.devssh/bin/devssh agent stop")
+		_, cmdErr := client.RunCommand("\"$HOME/.devssh/bin/devssh\" agent stop")
 		if cmdErr != nil {
-			pidCmd := "cat ~/.devssh/agent.pid | grep pid= | cut -d= -f2"
+			pidCmd := "cat \"$HOME/.devssh/agent.pid\" | grep pid= | cut -d= -f2"
 			pidOutput, _ := client.RunCommand(pidCmd)
 			return fmt.Errorf("failed to stop VSCode (pid: %s). Please manually kill the process and try again", strings.TrimSpace(pidOutput))
 		}

--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -201,7 +201,9 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 		client.RunCommand("\"$HOME/.devssh/bin/devssh\" agent stop")
 
 		logger.Infof("Removing existing VSCodium installation...")
-		client.RunCommand("rm -rf \"$HOME/.devssh/vscodium\"")
+		if _, err := client.RunCommand("rm -rf \"$HOME/.devssh/vscodium\""); err != nil {
+			logger.Warnf("Failed to remove old VSCodium installation, will attempt to overwrite: %v", err)
+		}
 
 		logger.Infof("Downloading VSCode %s for %s/%s...", version, remoteOS, remoteArch)
 		vscodePath, err := downloadVSCodeLocal(version, remoteOS, remoteArch, logger)
@@ -218,6 +220,16 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 		installCmd := fmt.Sprintf("install --local-tar \"$HOME/.devssh/vscodium-reh-web.tar.gz\" --version %s", version)
 		if _, err := runRemoteAgentCommand(client, installCmd); err != nil {
 			return fmt.Errorf("failed to install VSCode: %w", err)
+		}
+
+		postCheckCmd := "test -f \"$HOME/.devssh/vscodium/version\" && echo 'ok' || echo 'missing'"
+		postOutput, postErr := client.RunCommand(postCheckCmd)
+		if postErr != nil || strings.Contains(postOutput, "missing") {
+			logger.Warnf("VSCode version file is still missing after install, trying to create it manually")
+			writeVersionCmd := fmt.Sprintf("echo '%s' > \"$HOME/.devssh/vscodium/version\"", version)
+			if _, err := client.RunCommand(writeVersionCmd); err != nil {
+				return fmt.Errorf("failed to write version file: %w", err)
+			}
 		}
 	} else {
 		logger.Infof("VSCode is already installed, skipping installation")

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -171,8 +171,13 @@ func (r *Runner) Stop() error {
 }
 
 func (r *Runner) IsInstalled() bool {
-	_, err := os.Stat(r.serverPath)
-	return err == nil
+	if _, err := os.Stat(r.serverPath); err != nil {
+		return false
+	}
+	if _, err := os.Stat(r.versionFile); err != nil {
+		return false
+	}
+	return true
 }
 
 func (r *Runner) IsRunning() bool {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -86,13 +86,15 @@ func (r *Runner) Install(version string) error {
 
 	os.Remove(downloadPath)
 
-	r.saveVersion(version)
+	if err := r.saveVersion(version); err != nil {
+		logging.Warnf("Failed to save version file: %v", err)
+	}
 
 	return nil
 }
 
-func (r *Runner) saveVersion(version string) {
-	os.WriteFile(r.versionFile, []byte(version), 0644)
+func (r *Runner) saveVersion(version string) error {
+	return os.WriteFile(r.versionFile, []byte(version), 0644)
 }
 
 func (r *Runner) GetInstalledVersion() string {
@@ -389,7 +391,9 @@ func (r *Runner) InstallFromTar(tarPath string, version string) error {
 	}
 
 	if version != "" {
-		r.saveVersion(version)
+		if err := r.saveVersion(version); err != nil {
+			logging.Warnf("Failed to save version file: %v", err)
+		}
 	}
 
 	logging.Infof("VSCode installed successfully")

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"archive/tar"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,7 +29,6 @@ type Runner struct {
 	logFile        string
 	vscodiumDir    string
 	serverPath     string
-	versionFile    string
 	serverPID      int
 }
 
@@ -51,7 +51,6 @@ func NewRunner() (*Runner, error) {
 		logFile:     logFile,
 		vscodiumDir: vscodiumDir,
 		serverPath:  filepath.Join(vscodiumDir, "bin", "codium-server"),
-		versionFile: filepath.Join(vscodiumDir, "version"),
 	}, nil
 }
 
@@ -86,23 +85,22 @@ func (r *Runner) Install(version string) error {
 
 	os.Remove(downloadPath)
 
-	if err := r.saveVersion(version); err != nil {
-		logging.Warnf("Failed to save version file: %v", err)
-	}
-
 	return nil
 }
 
-func (r *Runner) saveVersion(version string) error {
-	return os.WriteFile(r.versionFile, []byte(version), 0644)
-}
-
 func (r *Runner) GetInstalledVersion() string {
-	data, err := os.ReadFile(r.versionFile)
+	productPath := filepath.Join(r.vscodiumDir, "product.json")
+	data, err := os.ReadFile(productPath)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(data))
+	var info struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &info); err != nil {
+		return ""
+	}
+	return info.Version
 }
 
 func (r *Runner) Start(port int) error {
@@ -174,7 +172,8 @@ func (r *Runner) IsInstalled() bool {
 	if _, err := os.Stat(r.serverPath); err != nil {
 		return false
 	}
-	if _, err := os.Stat(r.versionFile); err != nil {
+	productPath := filepath.Join(r.vscodiumDir, "product.json")
+	if _, err := os.Stat(productPath); err != nil {
 		return false
 	}
 	return true
@@ -393,12 +392,6 @@ func (r *Runner) InstallFromTar(tarPath string, version string) error {
 
 	if err := r.extract(tarPath); err != nil {
 		return fmt.Errorf("failed to extract: %w", err)
-	}
-
-	if version != "" {
-		if err := r.saveVersion(version); err != nil {
-			logging.Warnf("Failed to save version file: %v", err)
-		}
 	}
 
 	logging.Infof("VSCode installed successfully")

--- a/pkg/ssh/scp_client.go
+++ b/pkg/ssh/scp_client.go
@@ -40,7 +40,7 @@ func (s *SCPClient) Upload(localPath, remotePath string) error {
 
 	remoteDir := filepath.Dir(remotePath)
 	if remoteDir != "." && remoteDir != "/" {
-		mkdirCmd := fmt.Sprintf("mkdir -p %s", remoteDir)
+		mkdirCmd := fmt.Sprintf("mkdir -p \"%s\"", remoteDir)
 		if _, err := s.client.RunCommand(mkdirCmd); err != nil {
 			return fmt.Errorf("failed to create remote directory: %w", err)
 		}
@@ -66,7 +66,7 @@ func (s *SCPClient) uploadViaSSH(file *os.File, remotePath string, size int64, m
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 
-	if err := session.Start(fmt.Sprintf("scp -t %s", remotePath)); err != nil {
+	if err := session.Start(fmt.Sprintf("scp -t \"%s\"", remotePath)); err != nil {
 		return fmt.Errorf("failed to start SCP command: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func (s *SCPClient) Download(remotePath, localPath string) error {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 
-	if err := session.Start(fmt.Sprintf("scp -f %s", remotePath)); err != nil {
+	if err := session.Start(fmt.Sprintf("scp -f \"%s\"", remotePath)); err != nil {
 		return fmt.Errorf("failed to start SCP command: %w", err)
 	}
 
@@ -212,7 +212,7 @@ func (s *SCPClient) CheckRemoteFileExists(remotePath string) (bool, error) {
 		return false, fmt.Errorf("SSH client not connected")
 	}
 
-	checkCmd := fmt.Sprintf("test -f %s && echo exists", remotePath)
+	checkCmd := fmt.Sprintf("test -f \"%s\" && echo exists", remotePath)
 	output, err := s.client.RunCommand(checkCmd)
 	if err != nil {
 		return false, nil
@@ -226,7 +226,7 @@ func (s *SCPClient) GetRemoteFileSize(remotePath string) (int64, error) {
 		return 0, fmt.Errorf("SSH client not connected")
 	}
 
-	sizeCmd := fmt.Sprintf("stat -c %%s %s 2>/dev/null || wc -c < %s 2>/dev/null", remotePath, remotePath)
+	sizeCmd := fmt.Sprintf("stat -f %%z \"%s\" 2>/dev/null || stat -c %%s \"%s\" 2>/dev/null || wc -c < \"%s\" 2>/dev/null", remotePath, remotePath, remotePath)
 	output, err := s.client.RunCommand(sizeCmd)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get remote file size: %w", err)


### PR DESCRIPTION
## 问题

远程目标为 macOS 时，每次 `devssh up` 都会重新下载 devssh 和 codium-server，文件存在检测逻辑未能正确识别已下载的文件。

## 根因

### 1. `checkRemoteDevSSH` 的 shell 反模式

```bash
test -f ~/.../devssh && ~/.../devssh --version 2>/dev/null || echo 'not_found'
```

Shell 的 `&&`/`||` 优先级相同从左到右求值。若 `test -f` 成功但 `--version` 失败（macOS 上 Gatekeeper 阻止、二进制损坏等），`||` 分支触发 `echo 'not_found'`，函数认为文件不存在而触发重新下载。

### 2. 远程命令路径未引号包裹

所有 SSH 命令使用 `~/.devssh/...` 路径。`~` 展开后经过 shell word splitting，若 `$HOME` 包含空格（如 `/Users/First Last/`），路径被分割成多个参数，`test -f`、`mkdir -p`、`scp` 等全部失败。

### 3. `saveVersion` 错误被静默忽略

`os.WriteFile` 返回值被忽略。version 文件写入失败时不创建，下次连接 `cat ~/.../version` 返回 `unknown`，版本不匹配触发 codium-server 重新下载。

## 修改

| 文件 | 修改 |
|------|------|
| `cmd/devssh/up.go` | 1) `checkRemoteDevSSH` 拆为两步检测，避免 `&&`/`||` 反模式。2) 所有 `~` 路径改为 `"$HOME/..."` 引号包裹。3) `chmod +x` 错误不再静默忽略 |
| `pkg/ssh/scp_client.go` | 1) `mkdir -p`、`scp -t/-f`、`test -f` 路径加引号。2) `GetRemoteFileSize` 使用 macOS `stat -f %z` 作为首选，Linux `stat -c %s` 降级 |
| `pkg/agent/runner.go` | `saveVersion` 返回 error，调用处打印 warning |

## 验证

- `go build ./...` ✅
- `go vet ./...` ✅