### PR TITLE
chore: bump version from 0.1.8 to 0.1.9

### DIFF
--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	version = "0.1.8"
+	version = "0.1.9"
 	logger  log.Logger
 )
 

--- a/integration/devssh_test.go
+++ b/integration/devssh_test.go
@@ -184,7 +184,7 @@ exec socat TCP-LISTEN:$PORT,reuseaddr,fork SYSTEM:'printf "HTTP/1.1 200 OK\r\n\r
 }
 
 func (s *DevSSHIntegrationSuite) copyBinaryToArtifacts() {
-	devsshArtifact := filepath.Join(s.artifactDir, "devssh-0.1.8-linux-amd64")
+	devsshArtifact := filepath.Join(s.artifactDir, "devssh-0.1.9-linux-amd64")
 	input, err := os.ReadFile(s.binaryPath)
 	s.Require().NoError(err)
 	err = os.WriteFile(devsshArtifact, input, 0755)

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Sylens Wong <qiumin14@163.com>"]
 channels = ["conda-forge"]
 name = "DevSSH"
 platforms = ["linux-aarch64", "linux-64", "osx-arm64", "osx-64"]
-version = "0.1.8"
+version = "0.1.9"
 preview = ["pixi-build"]
 
 [tasks.clean_linux]
@@ -73,7 +73,7 @@ go = ">=1.25.4,<2"
 
 [package]
 name = "DevSSH"
-version = "0.1.8"
+version = "0.1.9"
 
 [package.build.backend]
 name = "pixi-build-rattler-build"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestGetDevSSHDownloadURL_Default(t *testing.T) {
-	url := GetDevSSHDownloadURL("0.1.8", "linux", "amd64")
-	assert.Equal(t, "https://github.com/SilenWang/DevSSH/releases/download/0.1.8/devssh-0.1.8-linux-amd64", url)
+	url := GetDevSSHDownloadURL("0.1.9", "linux", "amd64")
+	assert.Equal(t, "https://github.com/SilenWang/DevSSH/releases/download/0.1.9/devssh-0.1.9-linux-amd64", url)
 }
 
 func TestGetDevSSHDownloadURL_EnvOverride(t *testing.T) {
@@ -22,12 +22,12 @@ func TestGetDevSSHDownloadURL_EnvOverride(t *testing.T) {
 
 func TestGetDevSSHDownloadURL_EnvOverrideThenDefault(t *testing.T) {
 	os.Setenv(EnvDevSSHDownloadURL, "http://localhost:9999/test")
-	urlWithEnv := GetDevSSHDownloadURL("0.1.8", "linux", "amd64")
+	urlWithEnv := GetDevSSHDownloadURL("0.1.9", "linux", "amd64")
 	assert.Equal(t, "http://localhost:9999/test", urlWithEnv)
 	os.Unsetenv(EnvDevSSHDownloadURL)
 
-	urlDefault := GetDevSSHDownloadURL("0.1.8", "linux", "amd64")
-	assert.Equal(t, "https://github.com/SilenWang/DevSSH/releases/download/0.1.8/devssh-0.1.8-linux-amd64", urlDefault)
+	urlDefault := GetDevSSHDownloadURL("0.1.9", "linux", "amd64")
+	assert.Equal(t, "https://github.com/SilenWang/DevSSH/releases/download/0.1.9/devssh-0.1.9-linux-amd64", urlDefault)
 }
 
 func TestNewConfig(t *testing.T) {

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,6 +1,6 @@
 package:
   name: devssh
-  version: 0.1.8
+  version: 0.1.9
 
 source:
   path: .


### PR DESCRIPTION
Updates all version references from 0.1.8 to 0.1.9 across 5 files:

- cmd/devssh/main.go — embedded Go version string
- recipe.yaml — conda-build recipe version
- pixi.toml — workspace and package version
- pkg/config/config_test.go — download URL test cases
- integration/devssh_test.go — artifact name in integration test

Closes SIL-78