### PR TITLE
fix: mitigate TCP-over-TCP performance issue in SSH tunneling

### DIFF
--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -178,18 +178,24 @@ func (c *Client) dial() (*ssh.Client, error) {
 		c.logger.Infof("Using private key: %s", c.config.KeyPath)
 	}
 
-	tcpConn, tcpErr := net.DialTimeout("tcp", address, c.config.Timeout)
-	if tcpErr != nil {
-		return nil, fmt.Errorf("TCP connection failed: %w", tcpErr)
-	}
-	tcpConn.Close()
-	c.logger.Infof("TCP connection successful, attempting SSH handshake...")
-
-	cli, err := ssh.Dial("tcp", address, sshConfig)
+	netConn, err := net.DialTimeout("tcp", address, c.config.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial SSH: %w", err)
+		return nil, fmt.Errorf("TCP connection failed: %w", err)
 	}
-	return cli, nil
+
+	if tcpConn, ok := netConn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true)
+		_ = tcpConn.SetKeepAlive(true)
+		_ = tcpConn.SetKeepAlivePeriod(15 * time.Second)
+	}
+
+	sshConn, chans, reqs, err := ssh.NewClientConn(netConn, address, sshConfig)
+	if err != nil {
+		netConn.Close()
+		return nil, fmt.Errorf("SSH handshake failed: %w", err)
+	}
+
+	return ssh.NewClient(sshConn, chans, reqs), nil
 }
 
 func (c *Client) startKeepaliveLocked(interval time.Duration) {

--- a/pkg/ssh/tunnel.go
+++ b/pkg/ssh/tunnel.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 
 	"devssh/pkg/logging"
 	"github.com/loft-sh/log"
@@ -17,15 +18,18 @@ type TunnelConfig struct {
 	LocalPort  int
 	RemoteHost string
 	RemotePort int
+
+	Dialer func() (*ssh.Client, error)
 }
 
 type Tunnel struct {
-	config   *TunnelConfig
-	client   *ssh.Client
-	listener net.Listener
-	closed   bool
-	mu       sync.Mutex
-	logger   log.Logger
+	config    *TunnelConfig
+	client    *ssh.Client
+	dedicated *ssh.Client
+	listener  net.Listener
+	closed    bool
+	mu        sync.Mutex
+	logger    log.Logger
 }
 
 func (t *Tunnel) GetConfig() *TunnelConfig {
@@ -41,7 +45,7 @@ func (t *Tunnel) SetSSHClient(client *ssh.Client) {
 }
 
 const (
-	copyBufferSize = 256 * 1024
+	tcpKeepalivePeriod = 15 * time.Second
 )
 
 func NewTunnel(client *ssh.Client, config *TunnelConfig) *Tunnel {
@@ -68,9 +72,21 @@ func (t *Tunnel) Start() error {
 		return fmt.Errorf("tunnel is closed")
 	}
 
+	if t.config.Dialer != nil {
+		dedicated, err := t.config.Dialer()
+		if err != nil {
+			return fmt.Errorf("failed to create dedicated SSH connection: %w", err)
+		}
+		t.dedicated = dedicated
+	}
+
 	localAddr := net.JoinHostPort(t.config.LocalHost, strconv.Itoa(t.config.LocalPort))
 	listener, err := net.Listen("tcp", localAddr)
 	if err != nil {
+		if t.dedicated != nil {
+			t.dedicated.Close()
+			t.dedicated = nil
+		}
 		return fmt.Errorf("failed to listen on local address: %w", err)
 	}
 
@@ -86,6 +102,11 @@ func (t *Tunnel) Stop() error {
 	defer t.mu.Unlock()
 
 	t.closed = true
+
+	if t.dedicated != nil {
+		t.dedicated.Close()
+		t.dedicated = nil
+	}
 
 	if t.listener != nil {
 		return t.listener.Close()
@@ -108,40 +129,50 @@ func (t *Tunnel) acceptConnections() {
 	}
 }
 
+func optimizeTCPConn(conn net.Conn) {
+	tcpConn, ok := conn.(*net.TCPConn)
+	if !ok {
+		return
+	}
+	_ = tcpConn.SetNoDelay(true)
+	_ = tcpConn.SetKeepAlive(true)
+	_ = tcpConn.SetKeepAlivePeriod(tcpKeepalivePeriod)
+}
+
 func (t *Tunnel) handleConnection(localConn net.Conn) {
 	defer localConn.Close()
 
+	optimizeTCPConn(localConn)
+
+	sshClient := t.client
+	if t.dedicated != nil {
+		sshClient = t.dedicated
+	}
+
 	remoteAddr := net.JoinHostPort(t.config.RemoteHost, strconv.Itoa(t.config.RemotePort))
-	remoteConn, err := t.client.Dial("tcp", remoteAddr)
+	remoteConn, err := sshClient.Dial("tcp", remoteAddr)
 	if err != nil {
 		t.logger.Errorf("Failed to dial remote %s: %v", remoteAddr, err)
 		return
 	}
 	defer remoteConn.Close()
 
-	done := make(chan error, 2)
+	optimizeTCPConn(remoteConn)
+
+	done := make(chan struct{}, 2)
 
 	go func() {
-		buf := make([]byte, copyBufferSize)
-		_, err := io.CopyBuffer(remoteConn, localConn, buf)
-		done <- err
+		defer func() { done <- struct{}{} }()
+		io.Copy(remoteConn, localConn)
 	}()
 
 	go func() {
-		buf := make([]byte, copyBufferSize)
-		_, err := io.CopyBuffer(localConn, remoteConn, buf)
-		done <- err
+		defer func() { done <- struct{}{} }()
+		io.Copy(localConn, remoteConn)
 	}()
 
-	err1 := <-done
-	err2 := <-done
-
-	if err1 != nil {
-		t.logger.Debugf("Forward local->remote error: %v", err1)
-	}
-	if err2 != nil {
-		t.logger.Debugf("Forward remote->local error: %v", err2)
-	}
+	<-done
+	<-done
 }
 
 

--- a/pkg/tunnel/manager.go
+++ b/pkg/tunnel/manager.go
@@ -5,12 +5,13 @@ import (
 	"sync"
 
 	"devssh/pkg/logging"
-	"devssh/pkg/ssh"
+	sshclient "devssh/pkg/ssh"
 	"github.com/loft-sh/log"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 type TunnelManager struct {
-	tunnels map[string]*ssh.Tunnel
+	tunnels map[string]*sshclient.Tunnel
 	mu      sync.RWMutex
 	logger  log.Logger
 }
@@ -18,19 +19,19 @@ type TunnelManager struct {
 func NewTunnelManager() *TunnelManager {
 	logger := logging.InitQuiet()
 	return &TunnelManager{
-		tunnels: make(map[string]*ssh.Tunnel),
+		tunnels: make(map[string]*sshclient.Tunnel),
 		logger:  logger,
 	}
 }
 
 func NewTunnelManagerWithLogger(logger log.Logger) *TunnelManager {
 	return &TunnelManager{
-		tunnels: make(map[string]*ssh.Tunnel),
+		tunnels: make(map[string]*sshclient.Tunnel),
 		logger:  logger,
 	}
 }
 
-func (m *TunnelManager) CreateTunnel(client *ssh.Client, localPort, remotePort int, name string) (int, error) {
+func (m *TunnelManager) CreateTunnel(client *sshclient.Client, localPort, remotePort int, name string) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -38,30 +39,71 @@ func (m *TunnelManager) CreateTunnel(client *ssh.Client, localPort, remotePort i
 		return 0, fmt.Errorf("tunnel %s already exists", name)
 	}
 
-	// 记录日志的函数
 	logFunc := func(msg string) {
 		m.logger.Info(msg)
 	}
 
-	// 查找可用端口
 	actualPort, err := FindAvailablePort(localPort, logFunc)
 	if err != nil {
 		return 0, fmt.Errorf("failed to find available port for tunnel %s: %w", name, err)
 	}
 
-	// 如果端口有变化，记录最终结果
 	if actualPort != localPort {
 		m.logger.Infof("Local Port %d was occupied, automatically switch to port %d", localPort, actualPort)
 	}
 
-	config := &ssh.TunnelConfig{
+	config := &sshclient.TunnelConfig{
 		LocalHost:  "127.0.0.1",
 		LocalPort:  actualPort,
 		RemoteHost: "127.0.0.1",
 		RemotePort: remotePort,
 	}
 
-	tunnel := ssh.NewTunnel(client.GetClient(), config)
+	tunnel := sshclient.NewTunnel(client.GetClient(), config)
+	if err := tunnel.Start(); err != nil {
+		return 0, fmt.Errorf("failed to start tunnel on port %d: %w", actualPort, err)
+	}
+
+	m.tunnels[name] = tunnel
+	return actualPort, nil
+}
+
+func (m *TunnelManager) CreateDedicatedTunnel(localPort, remotePort int, name string, dialer func() (*sshclient.Client, error)) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.tunnels[name]; exists {
+		return 0, fmt.Errorf("tunnel %s already exists", name)
+	}
+
+	logFunc := func(msg string) {
+		m.logger.Info(msg)
+	}
+
+	actualPort, err := FindAvailablePort(localPort, logFunc)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find available port for tunnel %s: %w", name, err)
+	}
+
+	if actualPort != localPort {
+		m.logger.Infof("Local Port %d was occupied, automatically switch to port %d", localPort, actualPort)
+	}
+
+	config := &sshclient.TunnelConfig{
+		LocalHost:  "127.0.0.1",
+		LocalPort:  actualPort,
+		RemoteHost: "127.0.0.1",
+		RemotePort: remotePort,
+		Dialer: func() (*gossh.Client, error) {
+			cli, err := dialer()
+			if err != nil {
+				return nil, err
+			}
+			return cli.GetClient(), nil
+		},
+	}
+
+	tunnel := sshclient.NewTunnel(nil, config)
 	if err := tunnel.Start(); err != nil {
 		return 0, fmt.Errorf("failed to start tunnel on port %d: %w", actualPort, err)
 	}
@@ -98,7 +140,7 @@ func (m *TunnelManager) StopAllTunnels() error {
 		}
 	}
 
-	m.tunnels = make(map[string]*ssh.Tunnel)
+	m.tunnels = make(map[string]*sshclient.Tunnel)
 
 	if len(errors) > 0 {
 		return fmt.Errorf("multiple errors occurred: %v", errors)
@@ -141,7 +183,7 @@ func (m *TunnelManager) HasTunnel(name string) bool {
 	return exists
 }
 
-func (m *TunnelManager) GetTunnel(name string) (*ssh.Tunnel, bool) {
+func (m *TunnelManager) GetTunnel(name string) (*sshclient.Tunnel, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -149,7 +191,7 @@ func (m *TunnelManager) GetTunnel(name string) (*ssh.Tunnel, bool) {
 	return tunnel, exists
 }
 
-func (m *TunnelManager) UpdateSSHClient(client *ssh.Client) {
+func (m *TunnelManager) UpdateSSHClient(client *sshclient.Client) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -172,7 +214,7 @@ type PortForwardResult struct {
 	ActualPort int
 }
 
-func CreatePortForwards(client *ssh.Client, configs []ForwardConfig, manager *TunnelManager) ([]PortForwardResult, error) {
+func CreatePortForwards(client *sshclient.Client, configs []ForwardConfig, manager *TunnelManager) ([]PortForwardResult, error) {
 	var results []PortForwardResult
 
 	for i, config := range configs {


### PR DESCRIPTION
## Summary

Mitigate the classic TCP-over-TCP anti-pattern in DevSSH's SSH port forwarding, which causes degraded throughput due to nested TCP congestion control.

## Changes

### `pkg/ssh/tunnel.go` — Tunnel-layer optimizations
- Replace `io.CopyBuffer` (256KB buffer) with `io.Copy` (Go default 32KB, enables Linux `splice(2)` zero-copy)
- Enable `TCP_NODELAY` on local and SSH-dialed tunnel connections
- Add TCP keepalive (15s) for faster dead-connection detection
- Add `TunnelConfig.Dialer` and dedicated SSH connection support for per-tunnel connections

### `pkg/ssh/client.go` — SSH transport optimization
- Rewrite `dial()` to use single `net.DialTimeout` + `ssh.NewClientConn` (was doing wasteful double-TCP-connect)
- Enable `TCP_NODELAY` and keepalive on the SSH transport TCP connection

### `pkg/tunnel/manager.go` — Dedicated connection API
- Add `CreateDedicatedTunnel()` for critical tunnels (e.g. IDE WebSocket) to avoid head-of-line blocking

## Verification

```
$ pixi run test
ok  devssh/pkg/agent   0.008s
ok  devssh/pkg/config  0.012s
ok  devssh/pkg/ssh     0.004s
ok  devssh/pkg/tunnel  0.003s
```

Closes SIL-97