### PR TITLE
refactor: rename forward subcommand to fwd, add -P short flag for --ports

### DIFF
--- a/cmd/devssh/main.go
+++ b/cmd/devssh/main.go
@@ -207,7 +207,7 @@ func newForwardCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "forward [host]",
+		Use:   "fwd [host]",
 		Short: "Forward ports from remote host to local machine",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -356,7 +356,7 @@ func newForwardCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&port, "port", "p", "22", "SSH port")
 	cmd.Flags().StringVar(&keyPath, "key", "", "SSH private key path")
 	cmd.Flags().StringVar(&password, "password", "", "SSH password")
-	cmd.Flags().StringSliceVar(&forwards, "ports", []string{}, "Ports to forward (e.g., 3000, 8080:80)")
+	cmd.Flags().StringSliceVarP(&forwards, "ports", "P", []string{}, "Ports to forward (e.g., 3000, 8080:80)")
 	cmd.Flags().BoolVar(&auto, "auto", false, "Auto-detect and forward web service ports")
 	cmd.Flags().IntVar(&timeout, "timeout", 30, "SSH connection timeout in seconds")
 	cmd.Flags().BoolVar(&keepalive, "keepalive", true, "Enable SSH connection keepalive")

--- a/docs/Opencode_Document.md
+++ b/docs/Opencode_Document.md
@@ -60,10 +60,10 @@ devssh install user@hostname
 
 ```bash
 # 转发特定端口
-devssh forward user@hostname --ports 3000,8080:80
+devssh fwd user@hostname --ports 3000,8080:80
 
 # 自动检测并转发所有 Web 服务端口
-devssh forward user@hostname --auto
+devssh fwd user@hostname --auto
 ```
 
 ### 管理连接和配置
@@ -119,11 +119,11 @@ Flags:
       --timeout int SSH 连接超时时间（秒）(默认 30)
 ```
 
-### forward 命令
+### fwd 命令
 
 ```
 Usage:
-  devssh forward [host] [flags]
+  devssh fwd [host] [flags]
 
 Flags:
   -h, --help          帮助信息
@@ -131,7 +131,7 @@ Flags:
   -p, --port string   SSH 端口 (默认 "22")
       --key string    SSH 私钥路径
       --password string SSH 密码
-      --ports strings   要转发的端口 (例如: 3000, 8080:80)
+  -P, --ports strings   要转发的端口 (例如: 3000, 8080:80)
       --auto          自动检测运行的服务并转发其端口
       --timeout int   SSH 连接超时时间（秒）(默认 30)
 ```
@@ -364,8 +364,8 @@ devssh connect user@example.com --auto
 # 设置连接超时时间
 devssh connect user@example.com --timeout 60
 
-# 单独使用端口转发（forward命令用--ports）
-devssh forward user@example.com --ports 3000,8080:80
+# 单独使用端口转发（fwd命令用--ports）
+devssh fwd user@example.com --ports 3000,8080:80
 ```
 
 ### 示例 4：仅安装不连接

--- a/test_connection.sh
+++ b/test_connection.sh
@@ -16,8 +16,8 @@ echo "3. 显示 install 命令帮助："
 ./devssh install --help
 echo ""
 
-echo "4. 显示 forward 命令帮助："
-./devssh forward --help
+echo "4. 显示 fwd 命令帮助："
+./devssh fwd --help
 echo ""
 
 echo "5. 测试构建是否成功："


### PR DESCRIPTION
## Changes

- Rename `forward` subcommand to `fwd` (3-letter abbreviation)
- Add `-P` short flag for `--ports` parameter

## Files changed
- `cmd/devssh/main.go`: Update `Use` field and flag definition
- `docs/Opencode_Document.md`: Sync all references
- `test_connection.sh`: Update test command