### PR TITLE
feat: auto-open browser after devssh up starts IDE

### DIFF
--- a/cmd/devssh/up.go
+++ b/cmd/devssh/up.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -369,6 +371,12 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	}
 
 	logger.Infof("%s is now accessible at http://localhost:%d", ideType, actualIDEPort)
+
+	url := fmt.Sprintf("http://localhost:%d", actualIDEPort)
+	if err := openBrowser(url); err != nil {
+		logger.Warnf("Failed to open browser: %v", err)
+	}
+
 	logger.Infof("Press Ctrl+C to stop...")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -383,4 +391,19 @@ func doUpCommand(client *ssh.Client, host string, ideType string, idePort int, v
 	}
 
 	return nil
+}
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+	return cmd.Start()
 }


### PR DESCRIPTION
在 `devssh up` 成功启动 IDE 并建立端口转发后，自动尝试打开浏览器访问本地转发地址。

### 修改内容
- 新增 `openBrowser(url string) error` 函数，根据操作系统调用对应命令打开浏览器
  - Linux: xdg-open
  - macOS: open
  - Windows: rundll32
- 在 IDE URL 日志输出后自动调用 `openBrowser`
- 失败时仅输出 Warn 日志，不终止程序进程
- 端口由 `actualIDEPort` 变量动态确定，无硬编码

Closes #99