### PR TITLE
feat: include version number in build output filenames

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,23 +7,23 @@ version = "0.1.10"
 preview = ["pixi-build"]
 
 [tasks.clean_linux]
-cmd = "rm -f bin/devssh-linux-{{ arch }}"
+cmd = "VERSION=$(grep '^version =' pixi.toml | head -n 1 | sed 's/.*= \"\\(.*\\)\"/\\1/') && rm -f bin/devssh-$VERSION-linux-{{ arch }}"
 args = [{ arg = "arch", default = "amd64" }]
 cwd = "./"
 
 [tasks.build_linux_arch]
-cmd = "GOOS=linux GOARCH={{ arch }} go build -o bin/devssh-linux-{{ arch }} ./cmd/devssh/"
+cmd = "VERSION=$(grep '^version =' pixi.toml | head -n 1 | sed 's/.*= \"\\(.*\\)\"/\\1/') && GOOS=linux GOARCH={{ arch }} go build -o bin/devssh-$VERSION-linux-{{ arch }} ./cmd/devssh/"
 args = [{ arg = "arch", default = "amd64" }]
 cwd = "./"
 depends-on = [{ task = "clean_linux", args = ["{{ arch }}"] }]
 
 [tasks.clean_darwin]
-cmd = "rm -f bin/devssh-darwin-{{ arch }}"
+cmd = "VERSION=$(grep '^version =' pixi.toml | head -n 1 | sed 's/.*= \"\\(.*\\)\"/\\1/') && rm -f bin/devssh-$VERSION-darwin-{{ arch }}"
 args = [{ arg = "arch", default = "amd64" }]
 cwd = "./"
 
 [tasks.build_darwin_arch]
-cmd = "GOOS=darwin GOARCH={{ arch }} go build -o bin/devssh-darwin-{{ arch }} ./cmd/devssh/"
+cmd = "VERSION=$(grep '^version =' pixi.toml | head -n 1 | sed 's/.*= \"\\(.*\\)\"/\\1/') && GOOS=darwin GOARCH={{ arch }} go build -o bin/devssh-$VERSION-darwin-{{ arch }} ./cmd/devssh/"
 args = [{ arg = "arch", default = "amd64" }]
 cwd = "./"
 depends-on = [{ task = "clean_darwin", args = ["{{ arch }}"] }]


### PR DESCRIPTION
Build output binaries now follow the pattern `devssh-{version}-{os}-{arch}` (e.g. `devssh-0.1.10-linux-amd64`), with version dynamically parsed from `pixi.toml`.

**Changes:**
- Updated `clean_linux`, `build_linux_arch`, `clean_darwin`, `build_darwin_arch` task commands to extract version from `pixi.toml` and embed it in binary filenames

Closes SIL-102